### PR TITLE
Convert HTML to DocBook in EML

### DIFF
--- a/src/zenodo_to_gbif.Rmd
+++ b/src/zenodo_to_gbif.Rmd
@@ -85,12 +85,29 @@ index_para3 <- grep("Acknowledgements", paragraphs) + 1
 derived_paragraph <- tail(eml$dataset$abstract$para, 1)
 
 # Combine and update EML
-eml$dataset$abstract$para <- paragraphs[c(index_para1, index_para2, index_para3)] %>% 
+desired_paragraphs <- paragraphs[c(index_para1, index_para2, index_para3)] %>% 
   purrr::map_chr(movepub::html_to_docbook) %>% 
   # Add derived_paragrapg (in DocBook format)
-  append(derived_paragraph) %>% 
-  purrr::map_chr(~ paste0("<para>", .x, "</para>")) %>%
-  paste(collapse = "")
+  append(derived_paragraph)
+  #purrr::map_chr(~ paste0("<para>", .x, "</para>")) %>%
+  #paste(collapse = "")
+
+eml$dataset$abstract <- NULL
+eml$dataset$abstract <- 
+  list(
+    para = c(
+      desired_paragraphs[[1]],
+      desired_paragraphs[[2]],
+      desired_paragraphs[[3]],
+      desired_paragraphs[[4]]
+    )
+  )
+```
+
+Test if EML is valid:
+
+```{r}
+EML::eml_validate(eml)
 ```
 
 Write EML (again):

--- a/src/zenodo_to_gbif.Rmd
+++ b/src/zenodo_to_gbif.Rmd
@@ -74,7 +74,6 @@ paragraphs <- paragraphs[paragraphs != ""]
 # Keep desired paragraphs
 # 1: overview of the study (wrapped in CDATA)
 index_para1 <- grep(paste(project_id, "-"), paragraphs)[1]
-paragraphs[index_para1] <- paste0("<![CDATA[", paragraphs[index_para1], "]]>")
 
 # 2: Reference to paper
 index_para2 <- grep("for a more detailed description of this dataset", paragraphs)
@@ -86,8 +85,12 @@ index_para3 <- grep("Acknowledgements", paragraphs) + 1
 derived_paragraph <- tail(eml$dataset$abstract$para, 1)
 
 # Combine and update EML
-description <- paragraphs[c(index_para1, index_para2, index_para3)]
-eml$dataset$abstract$para <- c(description, derived_paragraph)
+eml$dataset$abstract$para <- paragraphs[c(index_para1, index_para2, index_para3)] %>% 
+  purrr::map_chr(movepub::html_to_docbook) %>% 
+  # Add derived_paragrapg (in DocBook format)
+  append(derived_paragraph) %>% 
+  purrr::map_chr(~ paste0("<para>", .x, "</para>")) %>%
+  paste(collapse = "")
 ```
 
 Write EML (again):

--- a/src/zenodo_to_gbif.Rmd
+++ b/src/zenodo_to_gbif.Rmd
@@ -61,7 +61,9 @@ eml <- movepub::write_eml(
 Process EML:
 
 ```{r}
-# Get description from Zenodo (with HTML, see https://github.com/inbo/movepub/issues/65)
+# Get description from Zenodo
+# - Has HTML, see https://github.com/inbo/movepub/issues/65)
+# - Doesn't include NOTES/CHANGELOG to description
 zenodo <- jsonlite::read_json(zenodo_url)
 description_full <- zenodo$metadata$description
 ```
@@ -72,7 +74,7 @@ paragraphs <- unlist(strsplit(description_full, "<p>|</p>|\n", perl = TRUE))
 paragraphs <- paragraphs[paragraphs != ""]
 
 # Keep desired paragraphs
-# 1: overview of the study (wrapped in CDATA)
+# 1: overview of the study
 index_para1 <- grep(paste(project_id, "-"), paragraphs)[1]
 
 # 2: Reference to paper
@@ -85,14 +87,13 @@ index_para3 <- grep("Acknowledgements", paragraphs) + 1
 derived_paragraph <- tail(eml$dataset$abstract$para, 1)
 
 # Combine and update EML
-desired_paragraphs <- paragraphs[c(index_para1, index_para2, index_para3)] %>% 
+desired_paragraphs <-
+  paragraphs[c(index_para1, index_para2, index_para3)] %>% 
+  # Convert to Docbook
   purrr::map_chr(movepub::html_to_docbook) %>% 
-  # Add derived_paragrapg (in DocBook format)
+  # Add derived paragraph (already in DocBook)
   append(derived_paragraph)
-  #purrr::map_chr(~ paste0("<para>", .x, "</para>")) %>%
-  #paste(collapse = "")
 
-eml$dataset$abstract <- NULL
 eml$dataset$abstract <- 
   list(
     para = c(


### PR DESCRIPTION
Fix #222 using new `movepub::html_to_docbook()` (see https://github.com/inbo/movepub/pull/103).

## Goals
- use layout in abstract/description, convert from HTML
- valid EML
- compatible with IPT

## Test
- [test-IPT](https://ipt.gbif-test.org/resource?r=o_westerschelde)
- [test-GBIF](https://www.gbif-test.org/dataset/17f548ab-8587-4f8c-8535-78760d918346#description)